### PR TITLE
bump fristenkalender-generator from 0.8.7 to 0.9.0 to include 2025-06-06

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,2 @@
 azure-functions
-fristenkalender_generator>=0.8.0
+fristenkalender_generator>=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,24 +6,24 @@
 #
 azure-functions==1.21.3
     # via -r requirements.in
-bdew-datetimes==0.7.1
+bdew-datetimes==0.8.0
     # via fristenkalender-generator
-fristenkalender-generator==0.8.7
+fristenkalender-generator==0.9.0
     # via -r requirements.in
-holidays==0.59
+holidays==0.62
     # via
     #   bdew-datetimes
     #   fristenkalender-generator
-icalendar==5.0.7
+icalendar==6.1.0
     # via fristenkalender-generator
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   bdew-datetimes
     #   holidays
     #   icalendar
-pytz==2023.3
-    # via
-    #   bdew-datetimes
-    #   icalendar
-six==1.16.0
+pytz==2024.2
+    # via bdew-datetimes
+six==1.17.0
     # via python-dateutil
+tzdata==2024.2
+    # via icalendar


### PR DESCRIPTION
instead of 2025-04-04 as sonderfeiertag
