### PR TITLE
feat: add authenticated read-only MCP server at /mcp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Copy to `.env` for LOCAL runs and adjust. All values here are non-secret public identifiers.
+#
+# On the Azure deployment there is NO .env file: the deploy is automated (`azd up` / Bicep on
+# GitHub release), and the MCP_AUTH0_* values are set from the Bicep container-app template
+# (infra/bicep/modules/container-app.bicep), not from the Azure Portal. See the README
+# "MCP Server" section.
+
+# --- MCP server (read-only, served at /mcp) ---------------------------------
+# Auth is OPTIONAL. Set BOTH of the following to protect /mcp with Auth0, or
+# leave BOTH unset to run /mcp unauthenticated (local dev). Setting exactly one
+# makes the app fail loudly on startup (a half-configured deployment is worse
+# than an obvious error).
+#
+# The MCP is an OAuth 2.1 resource server: it validates Auth0-issued bearer JWTs
+# and advertises the tenant via RFC 9728. There is NO client secret and NO
+# callback to register -- MCP clients self-register via Auth0 DCR + PKCE.
+
+# Auth0 issuer (the shared Hochfrequenz tenant). Same for every environment.
+# MCP_AUTH0_ISSUER_BASE_URL=https://auth.hochfrequenz.de/
+
+# The Auth0 API Identifier == the canonical /mcp URL of THIS deployment.
+# fristenkalender is prod-only, so there is one Auth0 API (prod):
+#   prod: https://fristenkalender-api.happyfield-64ecc075.westeurope.azurecontainerapps.io/mcp
+# MCP_AUTH0_AUDIENCE=https://fristenkalender-api.happyfield-64ecc075.westeurope.azurecontainerapps.io/mcp
+
+# Optional: RFC 9728 `resource` value. Defaults to MCP_AUTH0_AUDIENCE; only set
+# if the served URL differs from the audience.
+# MCP_RESOURCE=
+
+# Optional: set to false to skip mounting /mcp entirely.
+# MCP_ENABLE=true

--- a/README.md
+++ b/README.md
@@ -18,6 +18,47 @@ docker run -p 8000:80 ghcr.io/hochfrequenz/fristenkalender-functions:latest
 
 The API documentation is available at the [`/docs` endpoint (OpenAPI/Swagger UI)](https://fristenkalender-api.happyfield-64ecc075.westeurope.azurecontainerapps.io/docs).
 
+## MCP Server
+
+The same app also exposes a **read-only [MCP](https://modelcontextprotocol.io/) server** at
+`/mcp`, so agents (Claude, opencode, …) can call the Fristenkalender calculations as tools.
+It wraps the REST API 1:1 via `FastMCP.from_fastapi`, so the tool set always matches the
+OpenAPI spec. Only an explicit allowlist of the non-mutating JSON endpoints becomes tools
+(the two ICS-export endpoints are excluded); every tool is annotated `readOnlyHint`.
+
+Mirroring the sibling repos [`ahbicht-functions`](https://github.com/Hochfrequenz/ahbicht-functions)
+and [`ahb-tabellen`](https://github.com/Hochfrequenz/ahb-tabellen), `/mcp` is protected by
+**Auth0 as an OAuth 2.1 resource server**: it validates Auth0-issued bearer JWTs (RS256/JWKS)
+and advertises the tenant via [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) Protected
+Resource Metadata. There is no client secret — MCP clients self-register via Auth0 Dynamic
+Client Registration and do PKCE against `auth.hochfrequenz.de`.
+
+### Configuration
+
+Auth is controlled by two environment variables (see [`.env.example`](.env.example)); set
+**both** to enable it, or **neither** to run `/mcp` unauthenticated (local dev). Setting
+exactly one fails startup on purpose.
+
+| Variable | Value |
+| --- | --- |
+| `MCP_AUTH0_ISSUER_BASE_URL` | `https://auth.hochfrequenz.de/` |
+| `MCP_AUTH0_AUDIENCE` | the canonical `/mcp` URL of the deployment (prod: `https://fristenkalender-api.happyfield-64ecc075.westeurope.azurecontainerapps.io/mcp`) |
+
+On Azure these are set from the Bicep container-app template
+([`infra/bicep/modules/container-app.bicep`](infra/bicep/modules/container-app.bicep)) and
+applied automatically on the next release deploy — not via the Azure Portal. The matching
+Auth0 API (resource server) must be created once by hand.
+
+### Verifying a deployment
+
+```bash
+EXPECT_AUTH=1 scripts/verify-mcp.sh https://fristenkalender-api.happyfield-64ecc075.westeurope.azurecontainerapps.io
+```
+
+`EXPECT_AUTH=1` makes the script *require* auth to be on: it expects a `401` plus the RFC 9728
+metadata pointing at the Hochfrequenz Auth0 tenant, and fails if `/mcp` answers unauthenticated.
+Omit it for a local dev server running without auth.
+
 ## Local Setup
 
 Install the dependencies and run the application:

--- a/infra/bicep/modules/container-app.bicep
+++ b/infra/bicep/modules/container-app.bicep
@@ -72,6 +72,23 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             cpu: json('0.5')
             memory: '1Gi'
           }
+          // Read-only MCP server (served at /mcp) is protected as an Auth0 OAuth 2.1
+          // resource server. These are NON-SECRET public identifiers, so they live here
+          // as plain values (no secretRef). Setting BOTH enables auth; the app fails
+          // startup if exactly one is set (see app.mcp_server.settings).
+          // NOTE: MCP_AUTH0_AUDIENCE must equal the canonical prod /mcp URL. If the
+          // container app FQDN ever changes, update it here AND recreate the Auth0 API,
+          // or every token will silently 401.
+          env: [
+            {
+              name: 'MCP_AUTH0_ISSUER_BASE_URL'
+              value: 'https://auth.hochfrequenz.de/'
+            }
+            {
+              name: 'MCP_AUTH0_AUDIENCE'
+              value: 'https://fristenkalender-api.happyfield-64ecc075.westeurope.azurecontainerapps.io/mcp'
+            }
+          ]
         }
       ]
       scale: {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "fastapi[standard]==0.139.0",
     "fristenkalender-generator==1.0.4",
     "holidays==0.100",
+    "fastmcp>=3.4.3",
 ]
 dynamic = ["readme", "version"]
 

--- a/scripts/verify-mcp.sh
+++ b/scripts/verify-mcp.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Verify the /mcp endpoint of a fristenkalender-functions deployment.
+#
+# Checks (mirroring Hochfrequenz/ahbicht-functions & ahb-tabellen):
+#   1. the MCP endpoint answers at /mcp
+#   2. when auth is ON: RFC 9728 Protected Resource Metadata is public at
+#      /.well-known/oauth-protected-resource/mcp and points at the Auth0 tenant
+#   3. when auth is ON: an unauthenticated call is rejected with 401 +
+#      WWW-Authenticate carrying the resource_metadata pointer
+#
+# Usage:
+#   scripts/verify-mcp.sh <base-url>
+#   EXPECT_AUTH=1 scripts/verify-mcp.sh https://fristenkalender-api.happyfield-64ecc075.westeurope.azurecontainerapps.io
+#   scripts/verify-mcp.sh http://localhost:8000   # local dev (auth usually OFF)
+#
+# Set EXPECT_AUTH=1 to REQUIRE auth to be on (fail unless /mcp answers 401 + RFC 9728).
+# Use it for any real deployment -- otherwise a prod that silently shipped with auth
+# DISABLED (the worst misconfiguration this script exists to catch) would pass.
+#
+# Exit code is non-zero if any expected check fails.
+
+set -euo pipefail
+
+BASE="${1:-}"
+if [[ -z "$BASE" ]]; then
+  echo "usage: [EXPECT_AUTH=1] $0 <base-url>" >&2
+  exit 2
+fi
+BASE="${BASE%/}" # strip trailing slash
+EXPECT_AUTH="${EXPECT_AUTH:-}" # non-empty => auth MUST be on (a non-401 /mcp is a failure)
+
+fail=0
+note() { printf '  %s\n' "$1"; }
+ok() { printf '\033[32mPASS\033[0m %s\n' "$1"; }
+bad() {
+  printf '\033[31mFAIL\033[0m %s\n' "$1"
+  fail=1
+}
+
+echo "== verifying MCP at ${BASE}/mcp =="
+
+# 1. unauthenticated POST /mcp
+resp="$(curl -si -X POST "${BASE}/mcp" \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' || true)"
+# take the LAST HTTP status line so an informational 1xx (e.g. "100 Continue") is not mistaken
+# for the real status
+status="$(printf '%s' "$resp" | grep -iE '^HTTP/' | tail -1 | sed -E 's|^HTTP/[0-9.]+ ([0-9]{3}).*|\1|')"
+www_auth="$(printf '%s' "$resp" | grep -i '^www-authenticate:' || true)"
+
+case "$status" in
+  401)
+    ok "POST /mcp -> 401 (auth is ON)"
+    if printf '%s' "$www_auth" | grep -qi 'resource_metadata='; then
+      ok "WWW-Authenticate carries a resource_metadata pointer"
+    else
+      bad "401 without a WWW-Authenticate: Bearer resource_metadata=... header"
+      note "got: ${www_auth:-<none>}"
+    fi
+    # 2. Protected Resource Metadata must be public and point at the Hochfrequenz tenant
+    prm="$(curl -s "${BASE}/.well-known/oauth-protected-resource/mcp" || true)"
+    if printf '%s' "$prm" | grep -q '"authorization_servers"'; then
+      ok "RFC 9728 metadata is served"
+      note "$prm"
+      if printf '%s' "$prm" | grep -q 'auth\.hochfrequenz\.de'; then
+        ok "authorization server is the Hochfrequenz Auth0 tenant"
+      else
+        bad "metadata does not point at auth.hochfrequenz.de -- wrong/misconfigured tenant?"
+      fi
+    else
+      bad "no RFC 9728 metadata at /.well-known/oauth-protected-resource/mcp"
+      note "got: ${prm:-<none>}"
+    fi
+    ;;
+  200 | 202 | 400)
+    # 400 is the expected reply when auth is OFF and the probe carries no MCP session
+    # (fastmcp rejects a session-less tools/list). With auth ON the request is rejected
+    # with 401 *before* the session check, so a non-401 here always means "live + unauthenticated".
+    if [[ -n "$EXPECT_AUTH" ]]; then
+      bad "POST /mcp -> ${status} but EXPECT_AUTH=1 requires auth to be ON (expected 401)"
+      note "the deployment appears to have auth DISABLED -- check MCP_AUTH0_* on the app"
+    else
+      ok "POST /mcp -> ${status} (endpoint is live)"
+      note "auth appears DISABLED (no MCP_AUTH0_* set) -- fine for local/dev, NOT for prod"
+      [[ "$status" == "400" ]] && note "(400 = session-less probe rejected by the MCP transport; endpoint is up)"
+    fi
+    ;;
+  "")
+    bad "no HTTP status from ${BASE}/mcp -- is the app deployed and up?"
+    ;;
+  *)
+    bad "POST /mcp -> unexpected status ${status}"
+    note "$(printf '%s' "$resp" | head -1)"
+    ;;
+esac
+
+echo
+if [[ "$fail" -eq 0 ]]; then
+  echo "all checks passed"
+else
+  echo "some checks failed" >&2
+fi
+exit "$fail"

--- a/scripts/verify-mcp.sh
+++ b/scripts/verify-mcp.sh
@@ -46,7 +46,7 @@ resp="$(curl -si -X POST "${BASE}/mcp" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' || true)"
 # take the LAST HTTP status line so an informational 1xx (e.g. "100 Continue") is not mistaken
 # for the real status
-status="$(printf '%s' "$resp" | grep -iE '^HTTP/' | tail -1 | sed -E 's|^HTTP/[0-9.]+ ([0-9]{3}).*|\1|')"
+status="$(printf '%s' "$resp" | grep -iE '^HTTP/' | tail -1 | sed -E 's|^HTTP/[0-9.]+ ([0-9]{3}).*|\1|' || true)"
 www_auth="$(printf '%s' "$resp" | grep -i '^www-authenticate:' || true)"
 
 case "$status" in

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,12 +1,31 @@
 """FastAPI application for Fristenkalender."""
 
+from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
+from typing import Any, AsyncGenerator
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
+from app.mcp_server import attach_mcp
 from app.routers import calendar, fristen
+
+# assigned by attach_mcp() at the bottom of this module; referenced (late-bound) inside the
+# lifespan below. stays None only when the MCP is disabled via MCP_ENABLE=false.
+_mcp_app = None
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncGenerator[None, Any]:
+    """
+    Runs the MCP sub-app's lifespan (required for its session manager to initialise)
+    when the MCP is mounted; a no-op otherwise.
+    """
+    async with AsyncExitStack() as stack:
+        if _mcp_app is not None:
+            await stack.enter_async_context(_mcp_app.lifespan(_app))
+        yield
 
 
 class VersionInfo(BaseModel):
@@ -28,6 +47,7 @@ with open(_VERSION_FILE_PATH, encoding="utf-8", mode="r") as _version_file:
 app = FastAPI(
     title="Fristenkalender API",
     description="API for generating BDEW Fristenkalender deadlines",
+    lifespan=lifespan,
 )
 
 app.add_middleware(
@@ -52,6 +72,14 @@ def health():
 async def version() -> VersionInfo:
     """Returns the version of the server."""
     return _version
+
+
+# Serve the read-only MCP server (wraps the routes above) at /mcp, built after the routes and
+# endpoints are registered so the OpenAPI spec -- and thus the tool set -- is complete.
+# attach_mcp returns None only if disabled via MCP_ENABLE=false; a misconfiguration (e.g. only
+# one of the MCP_AUTH0_* pair) raises and aborts startup on purpose (see app.mcp_server.settings)
+# rather than silently leaving /mcp unauthenticated.
+_mcp_app = attach_mcp(app)
 
 
 __all__ = ["app"]

--- a/src/app/mcp_server/__init__.py
+++ b/src/app/mcp_server/__init__.py
@@ -1,0 +1,178 @@
+"""
+Read-only MCP server that wraps the existing FastAPI REST API.
+
+The whole point of this package is to add **no logic**: it re-exposes the very
+same endpoints as MCP tools via ``FastMCP.from_fastapi``, so the OpenAPI spec
+(and therefore the tool set) always stays in sync with the REST API.
+
+Design decisions (mirroring ``Hochfrequenz/ahbicht-functions`` and
+``Hochfrequenz/ahb-tabellen``):
+  * same image / same process -- the MCP is served on the existing app at ``/mcp``
+  * read-only -- only the explicitly allowlisted operationIds become tools
+    (:data:`_MCP_NAMES`); everything else is excluded, so a future write endpoint
+    can never silently become a callable tool
+  * auth -- Auth0 OAuth 2.1 *resource server* (validate bearer JWTs; advertise the
+    tenant via RFC 9728); optional in dev (see :mod:`app.mcp_server.settings`)
+"""
+
+import logging
+from typing import Any, Callable
+from urllib.parse import urlsplit
+
+from fastapi import FastAPI
+from fastmcp import FastMCP
+from fastmcp.server.auth import AuthProvider, JWTVerifier, RemoteAuthProvider
+from fastmcp.server.http import HostOriginGuardMiddleware, RequestContextMiddleware, StarletteWithLifespan
+from fastmcp.server.providers.openapi import MCPType
+from fastmcp.tools import Tool
+from mcp.types import ToolAnnotations
+from pydantic import AnyHttpUrl
+from starlette.routing import Route
+
+from .settings import McpSettings
+
+_logger = logging.getLogger(__name__)
+
+# key = the operationId FastAPI generates for a route; value = the MCP tool name we expose.
+#
+# We remap here (MCP only) rather than setting ``operation_id=`` on the routes to give the
+# LLM-facing tools clean, stable names without churning the REST operationIds (which feed the
+# OpenAPI spec / any generated clients). Keys must match app.openapi()["paths"][...]["operationId"]
+# (a test guards this); unmapped operations keep their auto-generated name, so a rename here is
+# cosmetic, never fatal.
+#
+# Allowlist = the JSON data endpoints only. The two ICS-export endpoints
+# (GenerateAndExport*) are intentionally left out: they return binary text/calendar file
+# downloads, which are not useful as MCP tools. They stay REST-only.
+_MCP_NAMES = {
+    "check_is_working_day_api_IsWorkingDay__check_date__get": "is_working_day",
+    "get_next_working_day_endpoint_api_NextWorkingDay__start_date__get": "next_working_day",
+    "get_previous_working_day_endpoint_api_PreviousWorkingDay__start_date__get": "previous_working_day",
+    "add_working_days_endpoint_api_AddWorkingDays__start_date___number_of_days__get": "add_working_days",
+    "add_calendar_days_endpoint_api_AddCalendarDays__start_date___number_of_days__get": "add_calendar_days",
+    "generate_all_fristen_api_GenerateAllFristen__year__get": "generate_all_fristen",
+    "generate_fristen_for_type_api_GenerateFristenForType__year___fristen_type__get": "generate_fristen_for_type",
+}
+
+
+def _build_route_map_fn() -> Callable[[Any, Any], MCPType]:
+    """
+    Return a route filter that enforces the read-only invariant *structurally*:
+    an operation becomes a TOOL only if its operationId is in the allowlist
+    (:data:`_MCP_NAMES`); anything else is EXCLUDED.
+
+    This does not rely on HTTP-verb heuristics, so a future ``POST /CreateFoo`` (or
+    any other write endpoint) can never silently turn into a callable tool -- it is
+    excluded until someone deliberately adds it to the allowlist.
+    """
+
+    def route_map_fn(route: Any, _route_type: Any) -> MCPType:  # (HTTPRoute, MCPType) -> MCPType
+        if route.operation_id in _MCP_NAMES:
+            return MCPType.TOOL
+        return MCPType.EXCLUDE
+
+    return route_map_fn
+
+
+def _annotate_read_only(_route: Any, component: Any) -> None:
+    """
+    Tag every exposed operation as a read-only MCP tool (``readOnlyHint``).
+
+    All our endpoints are non-mutating, and clients/LLMs use this hint to know a tool is
+    safe to call without side effects. FastMCP does not set it automatically for
+    OpenAPI-derived tools, so we set it here (called once per created component).
+    """
+    if isinstance(component, Tool):
+        base = component.annotations or ToolAnnotations()
+        component.annotations = base.model_copy(update={"readOnlyHint": True})
+
+
+def _build_auth(settings: McpSettings) -> AuthProvider | None:
+    """
+    Build an OAuth 2.1 resource-server auth provider, or ``None`` when auth is off.
+
+    We only *validate* Auth0-issued bearer JWTs (JWKS/RS256, ``iss``/``aud``/``exp``)
+    and advertise the tenant as the authorization server (RFC 9728). Clients self-register
+    via Auth0 DCR and do PKCE themselves -- no confidential client / client_secret on our side.
+    """
+    if not settings.auth_enabled:
+        _logger.warning("MCP auth is DISABLED (MCP_AUTH0_* not configured) -- do not do this in prod")
+        return None
+
+    verifier = JWTVerifier(
+        jwks_uri=settings.jwks_uri,
+        issuer=settings.issuer,
+        audience=settings.mcp_auth0_audience,
+    )
+    return RemoteAuthProvider(
+        token_verifier=verifier,
+        authorization_servers=[AnyHttpUrl(settings.issuer)],
+        # host root so the PRM lands at <root>/.well-known/oauth-protected-resource/mcp
+        base_url=settings.base_url,
+    )
+
+
+def attach_mcp(app: FastAPI) -> StarletteWithLifespan | None:
+    """
+    Build the MCP server from ``app`` and serve it at ``/mcp`` on the same app.
+
+    Returns the MCP ASGI sub-app (whose ``.lifespan`` the caller MUST chain into the
+    parent app's lifespan, or the MCP session manager never initialises), or ``None``
+    if the MCP is disabled.
+
+    We add the MCP routes to the parent app's router at **root level** rather than
+    ``app.mount("/mcp", ...)`` on purpose: RemoteAuthProvider serves the RFC 9728
+    Protected Resource Metadata at ``/.well-known/oauth-protected-resource/mcp`` (host
+    root, per RFC 9728 §3.1 path insertion). Mounting under ``/mcp`` would push that to
+    ``/mcp/.well-known/...`` and break MCP client discovery. ``http_app(path="/mcp")``
+    already serves the MCP endpoint at ``/mcp`` and the metadata at the correct root path.
+
+    Copying *routes* (not the sub-app) drops the sub-app's app-level middleware -- the part
+    that populates ``scope["user"]`` from the bearer token, the Host guard, and the request
+    context. So we re-attach that stack, but **only around the ``/mcp`` route**, never onto
+    the parent app. This is deliberate: the REST API must stay completely unauthenticated, so
+    no auth middleware may run for its requests. Without the auth middleware the ``/mcp``
+    route's ``RequireAuthMiddleware`` would reject even valid tokens with 401.
+
+    Host/Origin note: we keep FastMCP's Host guard (allow the canonical MCP host) as
+    defense-in-depth, but pass ``allowed_origins=["*"]`` -- the bearer token, not the Origin
+    header, is the security boundary here, and a strict Origin allow-list would 403 legitimate
+    cross-origin MCP clients (the failure would not show up in ``verify-mcp.sh``).
+    """
+    settings = McpSettings()
+    if not settings.mcp_enable:
+        _logger.info("MCP server disabled via MCP_ENABLE=false")
+        return None
+
+    auth = _build_auth(settings)
+    mcp = FastMCP.from_fastapi(
+        app=app,
+        name=f"{app.title} (MCP)",  # derive from the REST app's title; tag as the MCP surface
+        route_map_fn=_build_route_map_fn(),
+        mcp_component_fn=_annotate_read_only,  # every tool is annotated read-only
+        mcp_names=_MCP_NAMES,
+        auth=auth,  # forwarded to FastMCP.__init__; None means unauthenticated (dev)
+    )
+
+    mcp_app = mcp.http_app(path="/mcp")
+    # re-attach FastMCP's app-level middleware around ONLY the /mcp route so the REST API
+    # remains untouched (see docstring). Order inner->outer: RequireAuth (already on route.app)
+    # -> auth middleware -> Host guard -> request context (matches FastMCP's native stack).
+    for route in mcp_app.routes:
+        if isinstance(route, Route) and route.path == "/mcp":
+            wrapped = route.app
+            if auth is not None:
+                for middleware in reversed(auth.get_middleware()):
+                    wrapped = middleware.cls(wrapped, *middleware.args, **middleware.kwargs)
+                wrapped = HostOriginGuardMiddleware(
+                    wrapped,
+                    allowed_hosts=[urlsplit(settings.resource_uri).netloc],
+                    allowed_origins=["*"],
+                )
+            # populate get_http_request() for /mcp (fastmcp's own __init__ is untyped)
+            wrapped = RequestContextMiddleware(wrapped)  # type: ignore[no-untyped-call]
+            route.app = wrapped
+    # add /mcp and the /.well-known metadata route to the parent app at root (see docstring)
+    app.router.routes.extend(mcp_app.routes)
+    _logger.info("MCP server available at /mcp (auth=%s)", "on" if settings.auth_enabled else "OFF")
+    return mcp_app

--- a/src/app/mcp_server/settings.py
+++ b/src/app/mcp_server/settings.py
@@ -1,0 +1,99 @@
+"""
+Configuration for the (read-only) MCP server that wraps the REST API.
+
+The MCP endpoint is an OAuth 2.1 **resource server** (mirroring
+``Hochfrequenz/ahbicht-functions`` and ``Hochfrequenz/ahb-tabellen``): it
+*validates* Auth0-issued bearer JWTs and advertises the tenant as its
+authorization server via RFC 9728 metadata. It does **not** run the OAuth flow
+itself -- MCP clients (Claude etc.) self-register via Auth0's Dynamic Client
+Registration and do PKCE against ``auth.hochfrequenz.de``.
+
+Env vars mirror the sibling repos so cross-repo ops is uniform:
+  * ``MCP_AUTH0_ISSUER_BASE_URL``  e.g. ``https://auth.hochfrequenz.de/``
+  * ``MCP_AUTH0_AUDIENCE``         the Auth0 API identifier == canonical MCP URI,
+                                   e.g. ``https://fristenkalender-api.../mcp``
+  * ``MCP_RESOURCE``               RFC 9728 resource value; defaults to the audience
+  * ``MCP_ENABLE``                 set false to skip the mount entirely
+
+Auth is optional: set BOTH issuer and audience to enable it, NEITHER to run
+``/mcp`` unauthenticated (local dev / spike). Setting exactly one raises -- a
+partial config almost certainly means a misconfigured deployment, and silently
+exposing the endpoint would be worse. fristenkalender is prod-only, so one Auth0
+API is needed for prod (the canonical URI is the prod ``/mcp`` URL); on Azure
+these env vars are set from the Bicep container-app template, not manually.
+"""
+
+from urllib.parse import urlsplit, urlunsplit
+
+from pydantic import model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class McpSettings(BaseSettings):
+    """env-driven settings for the MCP wrapper; the tenant choice is just config"""
+
+    # No env_prefix: each field name IS its environment variable (case-insensitive), so
+    # there is no hidden prefix to reason about -- `mcp_enable` <-> MCP_ENABLE, etc.
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    # feature toggle: set MCP_ENABLE=false to skip mounting /mcp without code changes
+    mcp_enable: bool = True
+
+    # Auth0 resource-server config (all optional; validated as a pair below)
+    mcp_auth0_issuer_base_url: str | None = None
+    mcp_auth0_audience: str | None = None
+    mcp_resource: str | None = None  # defaults to the audience
+
+    @model_validator(mode="after")
+    def _check_auth_pair(self) -> "McpSettings":
+        """both issuer+audience, or neither -- a half-configured deployment must fail loudly"""
+        if bool(self.mcp_auth0_issuer_base_url) != bool(self.mcp_auth0_audience):
+            raise ValueError(
+                "MCP auth is partially configured: set BOTH MCP_AUTH0_ISSUER_BASE_URL and "
+                "MCP_AUTH0_AUDIENCE (or neither, to run /mcp unauthenticated)."
+            )
+        if self.mcp_auth0_audience:
+            # The advertised RFC 8707 resource is always <host>/mcp (see base_url), so the
+            # audience/resource must have exactly that path -- otherwise it would differ from
+            # the token `aud` and every real token would silently 401. Fail loudly instead.
+            resource = self.mcp_resource or self.mcp_auth0_audience
+            if urlsplit(resource).path != "/mcp":
+                raise ValueError(
+                    "MCP audience/resource must be the canonical MCP URI ending in exactly '/mcp' "
+                    f"(e.g. https://<host>/mcp); got path {urlsplit(resource).path!r}."
+                )
+        return self
+
+    @property
+    def auth_enabled(self) -> bool:
+        """True only when the Auth0 issuer+audience pair is present"""
+        return bool(self.mcp_auth0_issuer_base_url and self.mcp_auth0_audience)
+
+    @property
+    def issuer(self) -> str:
+        """normalised issuer with a single trailing slash (Auth0's ``iss`` form)"""
+        assert self.mcp_auth0_issuer_base_url is not None
+        return self.mcp_auth0_issuer_base_url.rstrip("/") + "/"
+
+    @property
+    def jwks_uri(self) -> str:
+        """Auth0 JWKS endpoint derived from the issuer (RS256 signature validation)"""
+        return self.issuer + ".well-known/jwks.json"
+
+    @property
+    def resource_uri(self) -> str:
+        """RFC 9728 resource == canonical MCP URI (defaults to the audience)"""
+        assert self.mcp_auth0_audience is not None
+        return self.mcp_resource or self.mcp_auth0_audience
+
+    @property
+    def base_url(self) -> str:
+        """
+        Host root of the resource URI (scheme + host, no path).
+
+        RemoteAuthProvider serves the PRM at ``<base_url>/.well-known/oauth-protected-resource<path>``
+        and reports ``resource = <base_url> + http_app_path("/mcp")``. Passing the host
+        root here keeps that equal to ``resource_uri`` when the audience is ``https://<host>/mcp``.
+        """
+        parts = urlsplit(self.resource_uri)
+        return urlunsplit((parts.scheme, parts.netloc, "", "", ""))

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -1,0 +1,16 @@
+from typing import Any, Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture(scope="function")
+def tester_client() -> Generator[TestClient, Any, None]:
+    """
+    A FastAPI TestClient created as a context manager so the app lifespan runs -- required
+    for the mounted MCP server's session manager to initialise (see app.main.lifespan).
+    """
+    with TestClient(app=app) as client:
+        yield client

--- a/unittests/test_mcp_server.py
+++ b/unittests/test_mcp_server.py
@@ -1,0 +1,409 @@
+"""
+Tests for the read-only MCP server that wraps the REST API (see app.mcp_server).
+
+These assert the *contract* we care about: the MCP is mounted, only the allowlisted
+(non-mutating) endpoints are exposed, the tool names are the clean remapped ones, auth
+is off in the test environment (no MCP_AUTH0_* configured) but wires up correctly when
+enabled, and a wrapped tool actually works end-to-end over an MCP session.
+"""
+
+import asyncio
+
+import pytest  # type: ignore[import]
+from fastapi.testclient import TestClient
+
+from app.main import _mcp_app, app
+from app.mcp_server import _MCP_NAMES, _annotate_read_only, _build_route_map_fn
+from app.mcp_server.settings import McpSettings
+
+
+def _build_test_mcp(fastapi_app):  # type: ignore[no-untyped-def]
+    """build an MCP from the app exactly as attach_mcp does (route filter + read-only tags)"""
+    from fastmcp import FastMCP
+
+    return FastMCP.from_fastapi(
+        app=fastapi_app,
+        name="test",
+        route_map_fn=_build_route_map_fn(),
+        mcp_component_fn=_annotate_read_only,
+        mcp_names=_MCP_NAMES,
+    )
+
+
+# the exact read-only tool set we expect (the JSON data endpoints; the two ICS-export
+# endpoints are intentionally excluded -- see app.mcp_server._MCP_NAMES)
+EXPECTED_TOOL_NAMES = {
+    "is_working_day",
+    "next_working_day",
+    "previous_working_day",
+    "add_working_days",
+    "add_calendar_days",
+    "generate_all_fristen",
+    "generate_fristen_for_type",
+}
+
+
+def _tool_names(fastapi_app) -> set[str]:
+    """build an MCP from the app the same way attach_mcp does and return its tool names"""
+    tools = asyncio.run(_build_test_mcp(fastapi_app)._list_tools())  # pylint: disable=protected-access
+    return {t.name for t in tools}
+
+
+def test_mcp_is_served_at_mcp_path() -> None:
+    """the MCP endpoint is served at /mcp on the main app (root-level, not mounted)"""
+    assert _mcp_app is not None, "MCP should be available (fastmcp installed)"
+    assert any(getattr(route, "path", "") == "/mcp" for route in app.routes)
+
+
+def test_only_expected_readonly_tools_are_exposed() -> None:
+    """exactly the allowlisted endpoints become tools; nothing more, nothing less"""
+    assert _tool_names(app) == EXPECTED_TOOL_NAMES
+
+
+def test_ics_export_endpoints_are_not_exposed_as_tools() -> None:
+    """
+    the two ICS-export endpoints return binary file downloads and are deliberately NOT
+    allowlisted -- they must never appear as MCP tools.
+    """
+    names = _tool_names(app)
+    assert not any("export" in n.lower() for n in names)
+    assert "generate_and_export_whole_calendar" not in names
+    assert "generate_and_export_fristen_for_type" not in names
+
+
+def test_only_allowlisted_operations_become_tools() -> None:
+    """
+    read-only is enforced structurally: an endpoint that is not in the allowlist is
+    excluded regardless of verb -- a new GET *or* a new write POST both stay out until
+    deliberately added to _MCP_NAMES.
+    """
+    from fastapi import FastAPI
+
+    throwaway = FastAPI()
+
+    @throwaway.post("/CreateFoo")  # a future write endpoint
+    async def create_foo() -> dict:  # pragma: no cover - never called
+        return {}
+
+    @throwaway.get("/NewReadThing")  # a future read endpoint, not yet allowlisted
+    async def new_read_thing() -> dict:  # pragma: no cover - never called
+        return {}
+
+    assert _tool_names(throwaway) == set(), "nothing outside the allowlist may become a tool"
+
+
+def test_mcp_names_keys_match_real_operation_ids() -> None:
+    """
+    guard for the fragile part: every _MCP_NAMES key must be a real operationId on the app,
+    otherwise the remap silently no-ops.
+    """
+    operation_ids = {op["operationId"] for methods in app.openapi()["paths"].values() for op in methods.values()}
+    unknown = set(_MCP_NAMES) - operation_ids
+    assert not unknown, f"_MCP_NAMES has keys that are not operationIds on the app: {unknown}"
+
+
+def test_all_tools_are_annotated_read_only() -> None:
+    """every exposed tool must carry readOnlyHint=True (this API is strictly read-only)"""
+    tools = asyncio.run(_build_test_mcp(app)._list_tools())  # pylint: disable=protected-access
+    assert tools, "expected some tools"
+    for tool in tools:
+        assert tool.annotations is not None and tool.annotations.readOnlyHint is True, tool.name
+
+
+def test_tool_names_are_the_clean_remapped_ones() -> None:
+    """every remapped name is present and the clunky auto-generated ones are gone"""
+    names = _tool_names(app)
+    assert set(_MCP_NAMES.values()) <= names
+    # none of the raw operationIds leaked through
+    assert not any(raw in names for raw in _MCP_NAMES)
+
+
+def _clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("MCP_AUTH0_ISSUER_BASE_URL", "MCP_AUTH0_AUDIENCE", "MCP_RESOURCE"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_auth_disabled_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """with no MCP_AUTH0_* env vars, auth is disabled (the dev bypass)"""
+    _clear_auth_env(monkeypatch)
+    assert McpSettings().auth_enabled is False
+
+
+def test_auth_enabled_when_issuer_and_audience_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """issuer + audience present -> auth is enabled, with derived jwks/base_url"""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("MCP_AUTH0_ISSUER_BASE_URL", "https://auth.hochfrequenz.de/")
+    monkeypatch.setenv("MCP_AUTH0_AUDIENCE", "https://fristenkalender-api.example/mcp")
+    settings = McpSettings()
+    assert settings.auth_enabled is True
+    assert settings.jwks_uri == "https://auth.hochfrequenz.de/.well-known/jwks.json"
+    # base_url is the host root so the RFC 9728 PRM lands at the correct path
+    assert settings.base_url == "https://fristenkalender-api.example"
+    assert settings.resource_uri == "https://fristenkalender-api.example/mcp"
+
+
+def test_partial_auth_config_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """exactly one of issuer/audience is a misconfig and must fail loudly, not silently open"""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("MCP_AUTH0_AUDIENCE", "https://fristenkalender-api.example/mcp")
+    with pytest.raises(ValueError, match="partially configured"):
+        McpSettings()
+
+
+def test_attach_mcp_propagates_partial_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    a half-configured deployment must abort startup, not be swallowed: attach_mcp lets the
+    partial-config error propagate (main.py calls it directly, with no error guard), so /mcp
+    is never left silently unmounted when auth was meant to be on.
+    """
+    from fastapi import FastAPI
+
+    from app.mcp_server import attach_mcp
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("MCP_AUTH0_ISSUER_BASE_URL", "https://auth.hochfrequenz.de/")  # audience missing
+    with pytest.raises(ValueError, match="partially configured"):
+        attach_mcp(FastAPI())
+
+
+def test_audience_must_end_in_mcp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    the advertised resource is always <host>/mcp, so an audience with a different/trailing
+    path would silently make every real token 401 -- it must fail loudly at config time.
+    """
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("MCP_AUTH0_ISSUER_BASE_URL", "https://auth.hochfrequenz.de/")
+    monkeypatch.setenv("MCP_AUTH0_AUDIENCE", "https://fristenkalender-api.example/mcp/")  # trailing slash
+    with pytest.raises(ValueError, match="ending in exactly '/mcp'"):
+        McpSettings()
+
+
+def test_rest_api_still_works_alongside_mcp(tester_client: TestClient) -> None:
+    """serving the MCP must not break the underlying REST endpoints"""
+    response = tester_client.get("/api/IsWorkingDay/2024-01-02")
+    assert response.status_code == 200
+    assert response.json()["is_working_day"] is True
+
+
+def _middleware_class_names(asgi_app: object) -> set[str]:
+    """unwrap a chain of ASGI middleware (each holds its inner app in `.app`) into class names"""
+    names: set[str] = set()
+    current = asgi_app
+    for _ in range(20):  # bounded; the real chain is short
+        names.add(type(current).__name__)
+        current = getattr(current, "app", None)
+        if current is None:
+            break
+    return names
+
+
+def test_auth_is_scoped_to_mcp_route_not_the_whole_app(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    The REST API must stay unauthenticated: auth middleware may wrap ONLY the /mcp route,
+    never the parent app. Regression for copying routes without the auth middleware (which
+    would 401 valid tokens) AND for accidentally authenticating the whole HTTP API.
+    """
+    from fastapi import FastAPI
+    from starlette.routing import Route
+
+    from app.mcp_server import attach_mcp
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("MCP_AUTH0_ISSUER_BASE_URL", "https://auth.hochfrequenz.de/")
+    monkeypatch.setenv("MCP_AUTH0_AUDIENCE", "http://testserver/mcp")
+
+    host_app = FastAPI()
+    attach_mcp(host_app)
+
+    # nothing auth-related on the parent app -> REST is untouched
+    app_level = {getattr(m.cls, "__name__", "") for m in host_app.user_middleware}
+    assert "AuthenticationMiddleware" not in app_level
+    assert "AuthContextMiddleware" not in app_level
+
+    # ...but the /mcp route itself is wrapped with the token-validation middleware
+    mcp_route = next(r for r in host_app.routes if isinstance(r, Route) and r.path == "/mcp")
+    on_route = _middleware_class_names(mcp_route.app)
+    assert "HostOriginGuardMiddleware" in on_route
+    assert "AuthenticationMiddleware" in on_route
+    assert "RequireAuthMiddleware" in on_route
+    assert "RequestContextMiddleware" in on_route
+
+
+def test_no_auth_middleware_when_auth_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """with auth off, the /mcp route carries no auth middleware (nothing to validate)"""
+    from fastapi import FastAPI
+    from starlette.routing import Route
+
+    from app.mcp_server import attach_mcp
+
+    _clear_auth_env(monkeypatch)
+    host_app = FastAPI()
+    attach_mcp(host_app)
+    mcp_route = next(r for r in host_app.routes if isinstance(r, Route) and r.path == "/mcp")
+    assert "AuthenticationMiddleware" not in _middleware_class_names(mcp_route.app)
+
+
+def test_valid_bearer_token_is_accepted() -> None:
+    """
+    End-to-end proof that the scoped auth wiring lets a *valid* token through (the case the
+    unauthenticated-401 test cannot see). Uses an HS256 verifier so the test can mint a token;
+    the /mcp route is wrapped with the same auth-middleware pattern as attach_mcp (the token
+    middleware from ``auth.get_middleware()``; the Host/RequestContext guards are omitted as
+    they are irrelevant to token validation). A valid token must get past auth (reaching the
+    session layer), not be rejected with 401.
+    """
+    import time
+    from contextlib import AsyncExitStack, asynccontextmanager
+    from typing import Any, AsyncGenerator
+
+    import jwt
+    from fastapi import FastAPI
+    from fastmcp import FastMCP
+    from fastmcp.server.auth import JWTVerifier, RemoteAuthProvider
+    from pydantic import AnyHttpUrl
+    from starlette.routing import Route
+
+    secret = "unit-test-secret-that-is-long-enough-for-hs256"  # >=32 bytes
+    issuer, audience = "https://auth.hochfrequenz.de/", "http://testserver/mcp"
+    auth = RemoteAuthProvider(
+        token_verifier=JWTVerifier(public_key=secret, algorithm="HS256", issuer=issuer, audience=audience),
+        authorization_servers=[AnyHttpUrl(issuer)],
+        base_url="http://testserver",
+    )
+    mcp_app = FastMCP(name="test", auth=auth).http_app(path="/mcp")
+    for route in mcp_app.routes:
+        if isinstance(route, Route) and route.path == "/mcp":
+            wrapped = route.app
+            for middleware in reversed(auth.get_middleware()):
+                wrapped = middleware.cls(wrapped, *middleware.args, **middleware.kwargs)
+            route.app = wrapped
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncGenerator[None, Any]:
+        async with AsyncExitStack() as stack:
+            await stack.enter_async_context(mcp_app.lifespan(app))
+            yield
+
+    host_app = FastAPI(lifespan=lifespan)
+    host_app.router.routes.extend(mcp_app.routes)
+
+    token = jwt.encode(
+        {"iss": issuer, "aud": audience, "sub": "tester", "iat": int(time.time()), "exp": int(time.time()) + 3600},
+        secret,
+        algorithm="HS256",
+    )
+    headers = {"accept": "application/json, text/event-stream"}
+    body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+    with TestClient(host_app) as client:
+        assert client.post("/mcp", headers=headers, json=body).status_code == 401  # no token
+        authed = client.post("/mcp", headers={**headers, "Authorization": f"Bearer {token}"}, json=body)
+        assert authed.status_code != 401, "a valid bearer token must pass auth (not be rejected)"
+
+
+def test_resource_server_prm_and_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    with auth enabled, serve RFC 9728 Protected Resource Metadata at the host-root path
+    and return 401 + WWW-Authenticate on /mcp.
+    """
+    from fastapi import FastAPI
+
+    from app.mcp_server import attach_mcp
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("MCP_AUTH0_ISSUER_BASE_URL", "https://auth.hochfrequenz.de/")
+    # audience host must line up with the TestClient host so resource == audience
+    monkeypatch.setenv("MCP_AUTH0_AUDIENCE", "http://testserver/mcp")
+
+    host_app = FastAPI()
+    attach_mcp(host_app)  # adds /mcp + the .well-known PRM route at root
+    client = TestClient(host_app)  # no lifespan needed: PRM + auth reject happen before the session manager
+
+    prm = client.get("/.well-known/oauth-protected-resource/mcp")
+    assert prm.status_code == 200
+    body = prm.json()
+    assert body["resource"] == "http://testserver/mcp"
+    assert body["authorization_servers"] == ["https://auth.hochfrequenz.de/"]
+
+    unauth = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert unauth.status_code == 401
+    assert "resource_metadata=" in unauth.headers.get("www-authenticate", "")
+
+    # a cross-origin client must not be blocked by the Host/Origin guard: it should reach
+    # auth (401 for the missing token), NOT be rejected 403 on Origin. Guards the allowed_origins fix.
+    cross_origin = client.post(
+        "/mcp", headers={"origin": "https://claude.ai"}, json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+    )
+    assert cross_origin.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: exercise a wrapped tool over a real MCP session
+# ---------------------------------------------------------------------------
+
+_MCP_HEADERS = {"accept": "application/json, text/event-stream", "content-type": "application/json"}
+
+
+def _mcp_session(client: TestClient) -> str:
+    """Open a new MCP session and return its session ID."""
+    resp = client.post(
+        "/mcp",
+        headers=_MCP_HEADERS,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest", "version": "1.0"},
+            },
+        },
+    )
+    assert resp.status_code == 200, f"MCP initialize failed: {resp.text}"
+    session_id: str = resp.headers["mcp-session-id"]
+    # Send the required `notifications/initialized` handshake
+    client.post(
+        "/mcp",
+        headers={**_MCP_HEADERS, "mcp-session-id": session_id},
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+    )
+    return session_id
+
+
+def _mcp_call(client: TestClient, session_id: str, call_id: int, tool: str, arguments: dict) -> dict:
+    """Invoke an MCP tool and return the parsed JSON-RPC result dict."""
+    import json
+
+    resp = client.post(
+        "/mcp",
+        headers={**_MCP_HEADERS, "mcp-session-id": session_id},
+        json={
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": arguments},
+        },
+    )
+    assert resp.status_code == 200, f"MCP tools/call HTTP error: {resp.status_code} {resp.text}"
+    for line in resp.text.splitlines():
+        if line.startswith("data: "):
+            return json.loads(line[6:])
+    raise AssertionError(f"No SSE data line found in response: {resp.text!r}")
+
+
+def test_is_working_day_tool_works_over_mcp_session(tester_client: TestClient) -> None:
+    """
+    A wrapped tool must be callable end-to-end over an MCP session and return the same
+    answer as the REST endpoint. 2024-01-01 (New Year) is not a BDEW working day.
+    """
+    session_id = _mcp_session(tester_client)
+    result = _mcp_call(
+        tester_client,
+        session_id,
+        call_id=2,
+        tool="is_working_day",
+        arguments={"check_date": "2024-01-01"},
+    )
+    assert result["result"].get("isError") is not True, f"tool call errored: {result}"
+    structured = result["result"]["structuredContent"]
+    assert structured["is_working_day"] is False


### PR DESCRIPTION
## What & why

Adds a **read-only, Auth0-authenticated MCP server** at `/mcp`, so agents (Claude, opencode, …) can call the Fristenkalender calculations as tools. It wraps the existing REST API 1:1 via `FastMCP.from_fastapi` — no new business logic — mirroring the proven setup in [`ahbicht-functions`](https://github.com/Hochfrequenz/ahbicht-functions) and [`ahb-tabellen`](https://github.com/Hochfrequenz/ahb-tabellen).

## How it works

- **Read-only, allowlisted.** Only the 7 non-mutating JSON endpoints become tools (`is_working_day`, `next_working_day`, `previous_working_day`, `add_working_days`, `add_calendar_days`, `generate_all_fristen`, `generate_fristen_for_type`). Exclusion is *structural* (an allowlist keyed on operationId), so a future write endpoint can never silently become a tool. The two ICS-export endpoints are excluded (they return binary file downloads). Every tool is annotated `readOnlyHint`.
- **Auth = OAuth 2.1 resource server.** Validates Auth0-issued bearer JWTs (RS256/JWKS), advertises the tenant via RFC 9728. No client secret — clients self-register via Auth0 DCR + PKCE. Auth is scoped to the `/mcp` route only; the REST API stays unauthenticated.
- **Config.** Set both `MCP_AUTH0_ISSUER_BASE_URL` + `MCP_AUTH0_AUDIENCE` to enable auth, neither to run unauthenticated (dev); exactly one fails startup on purpose.

## Differences from the sibling repos (by design)

- **Prod-only** (single Container App) → **one** Auth0 API, not stage+prod.
- **Automated deploy** (`azd up` / Bicep on release) → the `MCP_AUTH0_*` env vars are **baked into Bicep** (`infra/bicep/modules/container-app.bicep`) and applied on the next release, so there is **no manual env-var step**.

## Verification

- `pytest`: 49 passed (incl. new MCP contract + end-to-end session tests).
- `black` / `isort` / `pylint` (10.00/10) / `mypy` / `codespell`: clean.
- `scripts/verify-mcp.sh` run against a local server: auth-**on** → `401` + RFC 9728 PRM pointing at `auth.hochfrequenz.de`; auth-**off** → endpoint live.

## Manual follow-ups (separate issues)

1. #310 — **Create the prod Auth0 API** (resource server), identifier = the prod `/mcp` URL. ⚠️ The FQDN baked into Bicep is from the README and was **not** confirmed against live Azure (`az` unavailable during prep); confirm it before creating the API / merging.
2. #311 — **Verify `/mcp` live in prod** after the release deploy (depends on #310).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
