### PR TITLE
fix: set OpenAPI version from version.json (was FastAPI default 0.1.0)

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -47,6 +47,9 @@ with open(_VERSION_FILE_PATH, encoding="utf-8", mode="r") as _version_file:
 app = FastAPI(
     title="Fristenkalender API",
     description="API for generating BDEW Fristenkalender deadlines",
+    # surface the real deployed version (from version.json, written by the CD pipeline) in the
+    # OpenAPI spec instead of FastAPI's default "0.1.0"; drop the leading "v" of the git tag.
+    version=_version.tag.removeprefix("v"),
     lifespan=lifespan,
 )
 

--- a/unittests/test_app.py
+++ b/unittests/test_app.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 from fastapi.testclient import TestClient
 
-from app.main import app
+from app.main import _version, app
 
 client = TestClient(app)
 
@@ -30,6 +30,9 @@ class TestOpenApiDocs:
         assert response.status_code == HTTPStatus.OK
         openapi = response.json()
         assert openapi["info"]["title"] == "Fristenkalender API"
+        # the OpenAPI version must reflect the real deployed version, not FastAPI's default "0.1.0"
+        assert openapi["info"]["version"] != "0.1.0"
+        assert openapi["info"]["version"] == _version.tag.removeprefix("v")
         assert "/health" in openapi["paths"]
         assert "/api/GenerateAllFristen/{year}" in openapi["paths"]
 


### PR DESCRIPTION
## Problem
`/openapi.json` (and `/docs`) reported `info.version: 0.1.0` — FastAPI's default — because no `version=` was passed to `FastAPI(...)`, even though the app actually runs `v2.3.0` (confirmed live). `/version` was correct; only the OpenAPI spec was wrong.

## Fix
Thread the deployed tag from `version.json` (written by the CD pipeline) into `FastAPI(version=...)`, dropping the leading `v` (so `v2.3.0` → `2.3.0`). Locally, where `version.json` holds the placeholder, the placeholder shows instead — harmless and only affects local/untagged builds.

Adds a regression test in `test_app.py` asserting `info.version == _version.tag.removeprefix('v')` and `!= '0.1.0'`.

## Verification
pytest 49 passed · black/isort clean · pylint 10.00/10 · mypy clean. Will take effect on the next release deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)